### PR TITLE
Fix pre-commit checks failure

### DIFF
--- a/bloom/app.py
+++ b/bloom/app.py
@@ -1,4 +1,4 @@
-from fastapi import FastAPI, APIRouter
+from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from starlette.middleware.authentication import AuthenticationMiddleware
 import logging

--- a/bloom/auth/endpoints.py
+++ b/bloom/auth/endpoints.py
@@ -2,7 +2,6 @@ from fastapi import APIRouter, Depends, status, Header, HTTPException
 from fastapi.security import OAuth2PasswordRequestForm
 from datetime import datetime
 from sqlalchemy.orm import Session
-from bloom.jwt.schemas import TokenResponseSchema
 from bloom.postgres import get_db
 from bloom.auth.schemas import CreateUserRequest
 from bloom.security import get_password_hash

--- a/bloom/jwt/auth_handler.py
+++ b/bloom/jwt/auth_handler.py
@@ -7,7 +7,7 @@ from bloom.postgres import get_db
 
 def get_current_user(token: str = Depends(oauth2_scheme), db=None):
     payload = get_token_payload(token)
-    if not payload or type(payload) is not dict:
+    if not payload or not isinstance(payload, dict):
         return None
 
     user_id = payload.get("id", None)

--- a/bloom/security.py
+++ b/bloom/security.py
@@ -1,4 +1,3 @@
-import datetime
 from jose import JWTError, jwt
 from passlib.context import CryptContext
 from fastapi.security import OAuth2PasswordBearer


### PR DESCRIPTION
This commit addresses and resolves multiple issues identified by the pre-commit CI checks in #36 

1. Removed unused imports:
   - `fastapi.APIRouter` in bloom/app.py
   - `bloom.jwt.schemas.TokenResponseSchema` in bloom/auth/endpoints.py

2. Replaced type comparison with `isinstance()` as recommended in bloom/jwt/auth_handler.py.

3. Fixed the redefinition of unused `datetime` in bloom/security.py.

