### PR TITLE
Update .gitignore to Track Migration Files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,9 +82,6 @@ target/
 profile_default/
 ipython_config.py
 
-# Migrations
-migrations/versions/*.py
-
 # pyenv
 #   For a library or package, you might want to ignore these files since the code is
 #   intended to run in multiple environments; otherwise, check them in:


### PR DESCRIPTION
### Summary:
This pull request updates the `.gitignore` file to ensure that migration files within the `migrations/versions/` directory are tracked by Git. Previously, these files were inadvertently ignored, preventing them from being included in version control.

### Changes:
- Modified `.gitignore` to remove the line ignoring migration files in `migrations/versions/`.

### Impact:
With this change, any new migrations created will now be visible in `git status` and can be added to the repository as expected. This ensures that all developers working on this project have access to the latest database migrations, promoting consistency across different development environments.

### Testing:
After this change, I verified that running `git status` does show the migrations in the untracked files section. Future migrations should be tracked by default.
